### PR TITLE
re-enabled the mailer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 
 	<artifactId>quarantine</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.1-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 

--- a/src/main/java/org/jenkinsci/plugins/quarantine/MailNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/quarantine/MailNotifier.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.quarantine;
 
-import hudson.model.BuildListener;
 import hudson.model.Hudson;
+import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.tasks.Mailer;
 import hudson.tasks.junit.CaseResult;
@@ -53,7 +53,7 @@ public class MailNotifier {
    HashMap<String, List<ResultActionPair>> emailsToSend = new HashMap<String, List<ResultActionPair>>();
    PrintStream logger;
 
-   public MailNotifier(BuildListener build_listener) {
+   public MailNotifier(TaskListener build_listener) {
       logger = build_listener.getLogger();
    }
 

--- a/src/main/java/org/jenkinsci/plugins/quarantine/QuarantineTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/quarantine/QuarantineTestDataPublisher.java
@@ -34,8 +34,7 @@ public class QuarantineTestDataPublisher extends TestDataPublisher {
                                   TaskListener listener, TestResult testResult) {
       Data data = new Data(run);
 
-      // todo - review and re-enable mailer
-      //MailNotifier notifier = new MailNotifier(listener);
+      MailNotifier notifier = new MailNotifier(listener);
 
       for (SuiteResult suite : testResult.getSuites()) {
          for (CaseResult result : suite.getCases()) {
@@ -78,15 +77,13 @@ public class QuarantineTestDataPublisher extends TestDataPublisher {
                data.addQuarantine(result.getId(), action);
 
                // send email if failed
-               // todo - review and re-enable mailer
-//               if (!result.isPassed()) {
-//                  notifier.addResult(result, action);
-//               }
+               if (!result.isPassed()) {
+                  notifier.addResult(result, action);
+               }
             }
          }
       }
-      // todo - review and re-enable mailer
-      //notifier.sendEmails();
+      notifier.sendEmails();
       return data;
 
 
@@ -105,13 +102,13 @@ public class QuarantineTestDataPublisher extends TestDataPublisher {
       @Override
       public List<TestAction> getTestAction(@SuppressWarnings("deprecation")TestObject testObject) {
 
-         //todo - review this code from previous version and re-enable the statement
-//         if (build.getParent().getPublishersList().get(QuarantinableJUnitResultArchiver.class) == null) {
-//            // only display if QuarantinableJUnitResultArchiver chosen, to avoid
-//            // confusion
-//            System.out.println("not right publisher");
-//            return Collections.emptyList();
-//         }
+         Project project = (Project) build.getParent();
+         if (project != null &&  project.getPublishersList().get(QuarantinableJUnitResultArchiver.class) == null) {
+            // only display if QuarantinableJUnitResultArchiver chosen, to avoid
+            // confusion
+            System.out.println("not right publisher");
+            return Collections.emptyList();
+         }
 
          String id = testObject.getId();
          QuarantineTestAction result = quarantines.get(id);

--- a/src/test/java/org/jenkinsci/plugins/quarantine/QuarantineCoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/quarantine/QuarantineCoreTest.java
@@ -128,15 +128,16 @@ public class QuarantineCoreTest {
       }
    }
 
-   //mailer is currently disabled
-   @Ignore
+   @Test
    public void testNoTestsHaveQuarantineActionForStandardPublisher() throws Exception {
       project.getPublishersList().remove(QuarantinableJUnitResultArchiver.class);
 
       DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>> publishers = new DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>>(
               project);
       publishers.add(new QuarantineTestDataPublisher());
-      project.getPublishersList().add(new JUnitResultArchiver("*.xml", false, publishers));
+      JUnitResultArchiver jUnitResultArchiver = new JUnitResultArchiver("*.xml");
+      jUnitResultArchiver.setTestDataPublishers(publishers);
+      project.getPublishersList().add(jUnitResultArchiver);
 
       TestResult tr = getResultsFromJUnitResult("junit-1-failure.xml");
 
@@ -333,8 +334,7 @@ public class QuarantineCoreTest {
       assertEquals(1, report.getNumberOfSuccessivePasses(report.getQuarantinedTests().get(0)));
    }
 
-   //mailer is currently disabled
-   @Ignore
+   @Test
    public void testSendsEmailWhenQuarantinedFails() throws Exception {
       Mailbox.clearAll();
       TestResult tr = getResultsFromJUnitResult("junit-1-failure.xml");
@@ -358,8 +358,7 @@ public class QuarantineCoreTest {
       assertEquals(0, inbox.size());
    }
 
-   //mailer is currently disabled
-   @Ignore
+   @Test
    public void testTestEmailsAreCollatedWhenMultipleQuarantinedFail() throws Exception {
       Mailbox.clearAll();
       TestResult tr = getResultsFromJUnitResult("junit-1-failure.xml");


### PR DESCRIPTION
- re-enabled the mailer.
- fix the code to allow the `testNoTestsHaveQuarantineActionForStandardPublisher` test and its associated functionality to work:  functionality that doesn't allow this plugin's publisher to associate with publishers other than `QuarantinableJUnitResultArchiver`
- changed the version from 1.2 to 1.1 (1.2 made no sense)